### PR TITLE
Fixes #18

### DIFF
--- a/notify.admin.inc
+++ b/notify.admin.inc
@@ -655,7 +655,7 @@ function notify_admin_defaults($form, &$form_state) {
 
   $defnu = config_get('notify.settings', 'notify_reg_default');
   $perms = user_role_permissions(array(BACKDROP_ANONYMOUS_ROLE));
-  $anonp = array_key_exists('access notify', $perms);
+  $anonp = in_array('access notify', $perms);
   if ($defnu && !$anonp) {
     backdrop_set_message(t('If you want notification enabled by default for new users, you must grant the anonymous user role the permission to access notify.'), 'warning');
   }


### PR DESCRIPTION
Fixes error TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given a notify_admin_defaults() (línia 671 de /www/modules/notify/notify.admin.inc).